### PR TITLE
[FIX] add **kwargs to _setup_fields

### DIFF
--- a/booking_chart/view/booking.py
+++ b/booking_chart/view/booking.py
@@ -28,8 +28,8 @@ class BookingView(osv.Model):
     _inherit = 'ir.ui.view'
 
     @api.model
-    def _setup_fields(self):
-        res = super(BookingView, self)._setup_fields()
+    def _setup_fields(self, **kwargs):
+        res = super(BookingView, self)._setup_fields(**kwargs)
         select = [k for k, v in self._columns['type'].selection]
         if VIEW_TYPE[0] not in select:
             self._columns['type'].selection.append(VIEW_TYPE)


### PR DESCRIPTION
Commit fix issue below

Traceback (most recent call last):
  File "/mnt/files/src/odoo/openerp/http.py", line 524, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/mnt/files/src/odoo/openerp/http.py", line 545, in dispatch
    result = self._call_function(*_self.params)
  File "/mnt/files/src/odoo/openerp/http.py", line 301, in _call_function
    return checked_call(self.db, *args, *_kwargs)
  File "/mnt/files/src/odoo/openerp/service/model.py", line 113, in wrapper
    return f(dbname, _args, *_kwargs)
  File "/mnt/files/src/odoo/openerp/http.py", line 298, in checked_call
    return self.endpoint(_a, *_kw)
  File "/mnt/files/src/odoo/openerp/http.py", line 761, in __call__
    return self.method(_args, *_kw)
  File "/mnt/files/src/odoo/openerp/http.py", line 394, in response_wrap
    response = f(_args, *_kw)
  File "/mnt/files/src/odoo/addons/web/controllers/main.py", line 953, in call_button
    action = self._call_kw(model, method, args, {})
  File "/mnt/files/src/odoo/addons/web/controllers/main.py", line 941, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, _args, *_kwargs)
  File "/mnt/files/src/odoo/openerp/api.py", line 237, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/mnt/files/src/odoo/openerp/addons/base/module/module.py", line 450, in button_immediate_install
    return self._button_immediate_function(cr, uid, ids, self.button_install, context=context)
  File "/mnt/files/src/odoo/openerp/api.py", line 237, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/mnt/files/src/odoo/openerp/addons/base/module/module.py", line 498, in _button_immediate_function
    registry = openerp.modules.registry.RegistryManager.new(cr.dbname, update_module=True)
  File "/mnt/files/src/odoo/openerp/modules/registry.py", line 346, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/mnt/files/src/odoo/openerp/modules/loading.py", line 363, in load_modules
    loaded_modules, update_module)
  File "/mnt/files/src/odoo/openerp/modules/loading.py", line 263, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
  File "/mnt/files/src/odoo/openerp/modules/loading.py", line 162, in load_module_graph
    registry.setup_models(cr, partial=True)
  File "/mnt/files/src/odoo/openerp/modules/registry.py", line 174, in setup_models
    model._setup_fields(cr, SUPERUSER_ID, partial=partial)
  File "/mnt/files/src/odoo/openerp/api.py", line 237, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/mnt/files/src/odoo/openerp/api.py", line 332, in old_api
    result = method(recs, _args, *_kwargs)
TypeError: _setup_fields() got an unexpected keyword argument 'partial'
